### PR TITLE
feat: add item management APIs and refactor HTTP helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ MANIFEST
 *.log
 local_settings.py
 db.sqlite3
+publish_config.json
+.playwright-mcp/
+.spec-workflow/
 __pypackages__/
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ python manage_items.py delete --item-id 1234567890 --yes
 
 下架和删除会对线上商品执行真实变更，必须显式传入 `--yes`。
 
+### 发布商品
+
+先检查 `publish_config.json` 中的 `publish` 配置，再执行发布命令：
+
+```bash
+python publish_item.py
+```
+
+默认只会打印发布配置预览，不会真实发布。确认无误后再显式执行：
+
+```bash
+python publish_item.py --yes
+```
+
+发布会创建真实线上商品，必须显式传入 `--yes`。
+
 ---
 
 ## 项目结构
@@ -142,6 +158,7 @@ XianYuApis/
 ├── goofish_live.py      # 主入口：WebSocket 消息监听 & 回复逻辑（在此接入 AI）
 ├── goofish_apis.py      # HTTP API 封装（登录、刷新 Token、商品详情、上传媒体）
 ├── manage_items.py      # 商品列表、下架、删除命令行工具
+├── publish_item.py      # 商品发布命令行工具
 ├── publish_config.example.json # Cookie 与发布配置模板
 ├── message/
 │   ├── types.py         # 消息类型定义（TextContent / ImageContent / AudioContent）

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 | 商品信息 | 获取商品详情 | ✅ |
 | 媒体上传 | 上传图片并发送 | ✅ |
 | 登录 | 扫码获取cookie | ✅ |
+| 商品管理 | 获取我发布的商品列表、下架、删除 | ✅ |
 
 
 ---
@@ -96,12 +97,52 @@ python goofish_live.py
 
 ---
 
+## 商品管理命令
+
+商品管理命令依赖本地 `publish_config.json` 中的登录 Cookie。请先复制模板并填写自己的 Cookie：
+
+```bash
+cp publish_config.example.json publish_config.json
+```
+
+> `publish_config.json` 包含敏感 Cookie，已加入 `.gitignore`，不要提交到仓库。
+
+### 查看我发布的商品
+
+```bash
+python manage_items.py list --page-number 1 --page-size 20
+```
+
+### 查看商品数量摘要
+
+```bash
+python manage_items.py summary
+```
+
+### 下架指定商品
+
+```bash
+python manage_items.py down-shelf --item-id 1234567890 --yes
+```
+
+### 删除指定商品
+
+```bash
+python manage_items.py delete --item-id 1234567890 --yes
+```
+
+下架和删除会对线上商品执行真实变更，必须显式传入 `--yes`。
+
+---
+
 ## 项目结构
 
 ```
 XianYuApis/
 ├── goofish_live.py      # 主入口：WebSocket 消息监听 & 回复逻辑（在此接入 AI）
 ├── goofish_apis.py      # HTTP API 封装（登录、刷新 Token、商品详情、上传媒体）
+├── manage_items.py      # 商品列表、下架、删除命令行工具
+├── publish_config.example.json # Cookie 与发布配置模板
 ├── message/
 │   ├── types.py         # 消息类型定义（TextContent / ImageContent / AudioContent）
 ├── utils/

--- a/goofish_apis.py
+++ b/goofish_apis.py
@@ -1,9 +1,3 @@
-'''
-Description:
-Date: 2026-04-04 15:32:48
-LastEditTime: 2026-04-26 14:33:00
-FilePath: \XianYuApis\goofish_apis.py
-'''
 import json
 import os
 import subprocess
@@ -292,6 +286,47 @@ class XianyuApis:
         self.device_id = device_id
         self.cookies = {}
 
+    def _post_json_api(self, url, api, data_obj, version="1.0", spm_cnt="a21ybx.personal.0.0",
+                       spm_pre="a21ybx.personal.manage.1.default", log_id="personalManage"):
+        headers = {
+            "accept": "application/json",
+            "accept-language": "en,zh-CN;q=0.9,zh;q=0.8,zh-TW;q=0.7,ja;q=0.6",
+            "cache-control": "no-cache",
+            "content-type": "application/x-www-form-urlencoded",
+            "origin": "https://www.goofish.com",
+            "pragma": "no-cache",
+            "priority": "u=1, i",
+            "referer": "https://www.goofish.com/",
+            "sec-ch-ua": "\"Chromium\";v=\"146\", \"Not-A.Brand\";v=\"24\", \"Google Chrome\";v=\"146\"",
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": "\"Windows\"",
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "same-site",
+            "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
+        }
+        params = {
+            "jsv": "2.7.2",
+            "appKey": "34839810",
+            "t": str(int(time.time()) * 1000),
+            "sign": "",
+            "v": version,
+            "type": "originaljson",
+            "accountSite": "xianyu",
+            "dataType": "json",
+            "timeout": "20000",
+            "api": api,
+            "sessionOption": "AutoLoginOnly",
+            "spm_cnt": spm_cnt,
+            "spm_pre": spm_pre,
+            "log_id": log_id
+        }
+        data_val = json.dumps(data_obj, separators=(',', ':'))
+        token = self.session.cookies.get('_m_h5_tk', '').split('_')[0]
+        params['sign'] = generate_sign(params['t'], token, data_val)
+        response = self.session.post(url, headers=headers, params=params, data={"data": data_val})
+        return response.json()
+
     def get_token(self):
         headers = {
             "Host": "h5api.m.goofish.com",
@@ -454,6 +489,47 @@ class XianyuApis:
         response = self.session.post(self.item_detail_url, params=params, data=data)
         res_json = response.json()
         return res_json
+
+    def list_my_items(self, page_number: int = 1, page_size: int = 20, need_group_info: bool = True,
+                      user_id: Optional[str] = None):
+        user_id = user_id or self.session.cookies.get("unb", "")
+        data = {
+            "needGroupInfo": need_group_info,
+            "pageNumber": page_number,
+            "userId": str(user_id),
+            "pageSize": page_size
+        }
+        return self._post_json_api(
+            url="https://h5api.m.goofish.com/h5/mtop.idle.web.xyh.item.list/1.0/",
+            api="mtop.idle.web.xyh.item.list",
+            data_obj=data,
+            version="1.0",
+            spm_cnt="a21ybx.personal.0.0",
+            spm_pre="a21ybx.personal.manage.1.list",
+            log_id="personalListItems"
+        )
+
+    def down_shelf_item(self, item_id: str):
+        return self._post_json_api(
+            url="https://h5api.m.goofish.com/h5/mtop.taobao.idle.item.downshelf/2.0/",
+            api="mtop.taobao.idle.item.downshelf",
+            data_obj={"itemId": str(item_id)},
+            version="2.0",
+            spm_cnt="a21ybx.item.0.0",
+            spm_pre="a21ybx.personal.manage.1.downshelf",
+            log_id="itemDownShelf"
+        )
+
+    def delete_item(self, item_id: str):
+        return self._post_json_api(
+            url="https://h5api.m.goofish.com/h5/com.taobao.idle.item.delete/1.1/",
+            api="com.taobao.idle.item.delete",
+            data_obj={"itemId": str(item_id)},
+            version="1.1",
+            spm_cnt="a21ybx.item.0.0",
+            spm_pre="a21ybx.personal.manage.1.delete",
+            log_id="itemDelete"
+        )
 
 
     def get_public_channel(self, title, images_info):

--- a/manage_items.py
+++ b/manage_items.py
@@ -1,0 +1,186 @@
+import argparse
+import json
+from pathlib import Path
+
+from goofish_apis import XianyuApis
+from utils.goofish_utils import trans_cookies, generate_device_id
+
+
+def load_client() -> XianyuApis:
+    script_path = Path(__file__).resolve()
+    config_path = script_path.with_name("publish_config.json")
+    if not config_path.exists():
+        raise SystemExit("未找到 publish_config.json，请先补全配置。")
+
+    config = json.loads(config_path.read_text(encoding="utf-8-sig"))
+    cookies_str = config.get("cookies", "").strip()
+    if not cookies_str:
+        raise SystemExit("配置缺少 cookies 字段。")
+
+    cookies = trans_cookies(cookies_str)
+    if "unb" not in cookies:
+        raise SystemExit("cookies 缺少 unb 字段，无法生成 device_id。")
+
+    return XianyuApis(cookies, generate_device_id(cookies["unb"]))
+
+
+def find_first_item_list(payload):
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if isinstance(value, list) and value and all(isinstance(item, dict) for item in value):
+                lowered = key.lower()
+                if "item" in lowered or "list" in lowered:
+                    return value
+            nested = find_first_item_list(value)
+            if nested:
+                return nested
+    elif isinstance(payload, list):
+        for value in payload:
+            nested = find_first_item_list(value)
+            if nested:
+                return nested
+    return []
+
+
+def extract_summary(payload):
+    summary = {}
+    if not isinstance(payload, dict):
+        return summary
+
+    data = payload.get("data", payload)
+    for key in ("totalCount", "totalNum", "count", "itemCount"):
+        if isinstance(data, dict) and key in data and data[key]:
+            summary["total"] = data[key]
+            break
+
+    if isinstance(data, dict):
+        for key in ("groupInfos", "groupInfoList", "itemGroupList", "tabList"):
+            group_list = data.get(key)
+            if isinstance(group_list, list):
+                summary["groups"] = group_list
+                break
+
+    if "total" not in summary and summary.get("groups"):
+        for group in summary["groups"]:
+            if group.get("groupName") == "综合":
+                summary["total"] = group.get("itemNumber")
+                break
+
+    return summary
+
+
+def print_item_preview(payload):
+    items = find_first_item_list(payload.get("data", payload))
+    if not items:
+        return
+
+    print("商品预览:")
+    for item in items[:10]:
+        item_data = item.get("cardData", item)
+        detail_params = item_data.get("detailParams", {})
+        price_info = item_data.get("priceInfo", {})
+        item_id = (
+            item_data.get("itemId")
+            or item_data.get("id")
+            or item_data.get("item_id")
+            or detail_params.get("itemId")
+        )
+        title = (
+            item_data.get("title")
+            or item_data.get("itemTitle")
+            or item_data.get("name")
+            or item_data.get("itemName")
+            or item_data.get("idleTitle")
+            or detail_params.get("title")
+        )
+        price = (
+            item_data.get("price")
+            or item_data.get("itemPrice")
+            or price_info.get("price")
+            or detail_params.get("soldPrice")
+        )
+        print(f"- itemId={item_id} title={title} price={price}")
+
+
+def confirm_action(action: str, item_id: str, confirmed: bool):
+    if confirmed:
+        return
+    raise SystemExit(
+        "\n".join(
+            [
+                "⚠️ 危险操作检测！",
+                f"操作类型：{action}",
+                f"影响范围：itemId={item_id}",
+                "风险评估：会对线上闲鱼商品执行真实变更",
+                "",
+                "如确认执行，请重新运行并附加 --yes",
+            ]
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="闲鱼商品管理脚本")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="获取我发布的商品列表")
+    list_parser.add_argument("--page-number", type=int, default=1)
+    list_parser.add_argument("--page-size", type=int, default=20)
+    list_parser.add_argument("--no-group-info", action="store_true")
+
+    summary_parser = subparsers.add_parser("summary", help="获取当前商品数量摘要")
+    summary_parser.add_argument("--page-size", type=int, default=20)
+
+    down_shelf_parser = subparsers.add_parser("down-shelf", help="下架指定商品")
+    down_shelf_parser.add_argument("--item-id", required=True)
+    down_shelf_parser.add_argument("--yes", action="store_true")
+
+    delete_parser = subparsers.add_parser("delete", help="删除指定商品")
+    delete_parser.add_argument("--item-id", required=True)
+    delete_parser.add_argument("--yes", action="store_true")
+
+    args = parser.parse_args()
+    client = load_client()
+
+    if args.command == "list":
+        result = client.list_my_items(
+            page_number=args.page_number,
+            page_size=args.page_size,
+            need_group_info=not args.no_group_info,
+        )
+        print_item_preview(result)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.command == "summary":
+        result = client.list_my_items(page_number=1, page_size=args.page_size, need_group_info=True)
+        summary = extract_summary(result)
+        groups = []
+        for group in summary.get("groups", []):
+            groups.append(
+                {
+                    "groupName": group.get("groupName"),
+                    "itemNumber": group.get("itemNumber"),
+                    "groupId": group.get("groupId"),
+                }
+            )
+        print(json.dumps({"total": summary.get("total", 0), "groups": groups}, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.command == "down-shelf":
+        confirm_action("下架商品", args.item_id, args.yes)
+        result = client.down_shelf_item(args.item_id)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.command == "delete":
+        confirm_action("删除商品", args.item_id, args.yes)
+        result = client.delete_item(args.item_id)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    raise SystemExit(f"不支持的命令: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/publish_config.example.json
+++ b/publish_config.example.json
@@ -1,0 +1,15 @@
+{
+  "cookies": "your_cookie_string_here",
+  "publish": {
+    "images_path": [
+      "C:/path/to/image-1.png"
+    ],
+    "goods_desc": "商品描述文案",
+    "price": 99.9,
+    "delivery": {
+      "choice": "邮寄",
+      "post_price": 0,
+      "can_self_pickup": false
+    }
+  }
+}

--- a/publish_item.py
+++ b/publish_item.py
@@ -1,0 +1,86 @@
+import argparse
+import json
+from pathlib import Path
+
+from goofish_apis import XianyuApis
+from utils.goofish_utils import trans_cookies, generate_device_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="闲鱼商品发布脚本")
+    parser.add_argument("--yes", action="store_true", help="确认执行真实发布")
+    args = parser.parse_args()
+
+    script_path = Path(__file__).resolve()
+    config_path = script_path.with_name("publish_config.json")
+
+    if not config_path.exists():
+        print("未找到 publish_config.json，请先根据模板创建配置文件。")
+        return 1
+
+    config = json.loads(config_path.read_text(encoding="utf-8-sig"))
+    cookies_str = config.get("cookies", "").strip()
+    if not cookies_str:
+        print("配置缺少 cookies 字段")
+        return 1
+
+    cookies = trans_cookies(cookies_str)
+    if "unb" not in cookies:
+        print("cookies 缺少 unb 字段，无法生成 device_id")
+        return 1
+
+    xianyu = XianyuApis(cookies, generate_device_id(cookies["unb"]))
+
+    publish_cfg = config.get("publish", {})
+    images_path = publish_cfg.get("images_path", [])
+    goods_desc = publish_cfg.get("goods_desc", "")
+    price = publish_cfg.get("price", None)
+    delivery = publish_cfg.get("delivery", {})
+
+    if not goods_desc:
+        print("publish.goods_desc 不能为空")
+        return 1
+    if not images_path:
+        print("publish.images_path 至少需要 1 张图片")
+        return 1
+    if not delivery:
+        print("publish.delivery 不能为空")
+        return 1
+
+    preview = {
+        "images_path": images_path,
+        "goods_desc": goods_desc,
+        "price": price,
+        "delivery": delivery,
+    }
+
+    if not args.yes:
+        print(
+            "\n".join(
+                [
+                    "⚠️ 危险操作检测！",
+                    "操作类型：发布商品",
+                    "影响范围：会使用 publish_config.json 中的配置发布线上闲鱼商品",
+                    "风险评估：发布成功后会产生真实线上商品，需要后续手工下架或删除",
+                    "",
+                    "发布配置预览：",
+                    json.dumps(preview, ensure_ascii=False, indent=2),
+                    "",
+                    "如确认执行，请重新运行并附加 --yes",
+                ]
+            )
+        )
+        return 1
+
+    res = xianyu.public(
+        images_path=images_path,
+        goods_desc=goods_desc,
+        price=price,
+        ds=delivery,
+    )
+    print(json.dumps(res, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/goofish_utils.py
+++ b/utils/goofish_utils.py
@@ -2,16 +2,15 @@ import base64
 import json
 import subprocess
 from functools import partial
+from pathlib import Path
 
 import blackboxprotobuf
 
 subprocess.Popen = partial(subprocess.Popen, encoding="utf-8")
 import execjs
 
-try:
-    xianyu_js = execjs.compile(open(r'../static/goofish_js_version_2.js', 'r', encoding='utf-8').read())
-except:
-    xianyu_js = execjs.compile(open(r'static/goofish_js_version_2.js', 'r', encoding='utf-8').read())
+STATIC_JS_PATH = Path(__file__).resolve().parents[1] / "static" / "goofish_js_version_2.js"
+xianyu_js = execjs.compile(STATIC_JS_PATH.read_text(encoding="utf-8"))
 
 def trans_cookies(cookies_str):
     cookies = dict()


### PR DESCRIPTION
## Summary
- add reusable JSON MTOP POST helper
- add personal item list API wrapper
- add item down-shelf and delete API wrappers
- make Goofish JS path resolution independent of current working directory

## Notes
- item publish flow is unchanged
- no credentials or local publish config are included